### PR TITLE
Prototype for <vaadin-message> options menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@polymer/polymer": "^3.0.0",
     "@vaadin/vaadin-avatar": "^1.0.3",
     "@vaadin/vaadin-button": "^2.4.0",
-    "@vaadin/vaadin-context-menu": "^5.0.0",
+    "@vaadin/vaadin-context-menu": "^4.5.0",
     "@vaadin/vaadin-element-mixin": "^2.4.1",
     "@vaadin/vaadin-icons": "^4.3.2",
     "@vaadin/vaadin-item": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,10 @@
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
     "@vaadin/vaadin-avatar": "^1.0.3",
+    "@vaadin/vaadin-button": "^2.4.0",
+    "@vaadin/vaadin-context-menu": "^5.0.0",
     "@vaadin/vaadin-element-mixin": "^2.4.1",
+    "@vaadin/vaadin-icons": "^4.3.2",
     "@vaadin/vaadin-lumo-styles": "^1.6.1",
     "@vaadin/vaadin-material-styles": "^1.3.2",
     "@vaadin/vaadin-themable-mixin": "^1.6.1"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
     "@vaadin/vaadin-context-menu": "^5.0.0",
     "@vaadin/vaadin-element-mixin": "^2.4.1",
     "@vaadin/vaadin-icons": "^4.3.2",
+    "@vaadin/vaadin-item": "^2.3.0",
+    "@vaadin/vaadin-list-box": "^1.4.0",
     "@vaadin/vaadin-lumo-styles": "^1.6.1",
     "@vaadin/vaadin-material-styles": "^1.3.2",
     "@vaadin/vaadin-themable-mixin": "^1.6.1"

--- a/src/vaadin-message-context-menu.js
+++ b/src/vaadin-message-context-menu.js
@@ -15,7 +15,6 @@ class MessageContextMenuElement extends ContextMenuElement {
 
   constructor() {
     super();
-
     this.openOn = 'opensubmenu';
   }
 

--- a/src/vaadin-message-context-menu.js
+++ b/src/vaadin-message-context-menu.js
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright (c) 2020 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ContextMenuElement } from '@vaadin/vaadin-context-menu/src/vaadin-context-menu.js';
+
+/**
+ * @extends PolymerElement
+ */
+class MessageContextMenuElement extends ContextMenuElement {
+  static get is() {
+    return 'vaadin-message-context-menu';
+  }
+
+  constructor() {
+    super();
+
+    this.openOn = 'opensubmenu';
+  }
+
+  /**
+   * Overriding the observer to not add global "contextmenu" listener.
+   */
+  _openedChanged(opened) {
+    this.$.overlay.opened = opened;
+  }
+
+  /**
+   * Overriding the public method to reset expanded button state.
+   */
+  close() {
+    super.close();
+
+    // only handle 1st level submenu
+    if (this.hasAttribute('is-root')) {
+      this.getRootNode().host._close();
+    }
+  }
+}
+
+customElements.define(MessageContextMenuElement.is, MessageContextMenuElement);

--- a/src/vaadin-message-menu-button.js
+++ b/src/vaadin-message-menu-button.js
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright (c) 2020 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ButtonElement } from '@vaadin/vaadin-button/src/vaadin-button.js';
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+
+registerStyles(
+  'vaadin-message-menu-button',
+  css`
+    :host {
+      flex-shrink: 0;
+      line-height: 1;
+    }
+  `,
+  { moduleId: 'vaadin-message-menu-button-styles' }
+);
+
+/**
+ * @extends PolymerElement
+ */
+class MessageMenuButtonElement extends ButtonElement {
+  ready() {
+    super.ready();
+  }
+
+  static get is() {
+    return 'vaadin-message-menu-button';
+  }
+}
+
+customElements.define(MessageMenuButtonElement.is, MessageMenuButtonElement);

--- a/src/vaadin-message-menu-item.js
+++ b/src/vaadin-message-menu-item.js
@@ -6,14 +6,7 @@
 import { ItemElement } from '@vaadin/vaadin-item/src/vaadin-item.js';
 import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
-registerStyles(
-  'vaadin-message-menu-item',
-  css`
-    :host {
-    }
-  `,
-  { moduleId: 'vaadin-message-menu-item-styles' }
-);
+registerStyles('vaadin-message-menu-item', css``, { moduleId: 'vaadin-message-menu-item-styles' });
 
 /**
  * @extends PolymerElement
@@ -21,6 +14,7 @@ registerStyles(
 class MessageMenuItemElement extends ItemElement {
   ready() {
     super.ready();
+    this.setAttribute('role', 'menuitem');
   }
 
   static get is() {

--- a/src/vaadin-message-menu-item.js
+++ b/src/vaadin-message-menu-item.js
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright (c) 2020 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ItemElement } from '@vaadin/vaadin-item/src/vaadin-item.js';
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+
+registerStyles(
+  'vaadin-message-menu-item',
+  css`
+    :host {
+    }
+  `,
+  { moduleId: 'vaadin-message-menu-item-styles' }
+);
+
+/**
+ * @extends PolymerElement
+ */
+class MessageMenuItemElement extends ItemElement {
+  ready() {
+    super.ready();
+  }
+
+  static get is() {
+    return 'vaadin-message-menu-item';
+  }
+}
+
+customElements.define(MessageMenuItemElement.is, MessageMenuItemElement);

--- a/src/vaadin-message-menu-list-box.js
+++ b/src/vaadin-message-menu-list-box.js
@@ -6,14 +6,7 @@
 import { ListBoxElement } from '@vaadin/vaadin-list-box/src/vaadin-list-box.js';
 import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
-registerStyles(
-  'vaadin-message-menu-list-box',
-  css`
-    :host {
-    }
-  `,
-  { moduleId: 'vaadin-message-menu-list-box-styles' }
-);
+registerStyles('vaadin-message-menu-list-box', css``, { moduleId: 'vaadin-message-menu-list-box-styles' });
 
 /**
  * @extends PolymerElement
@@ -21,6 +14,11 @@ registerStyles(
 class MessageMenuListBoxElement extends ListBoxElement {
   ready() {
     super.ready();
+
+    // We'll need to move <vaadin-message-list>'s <vaadin-message>s to Light DOM to improve a11y
+    this.setAttribute('aria-labelledby', 'menu-button');
+    this.setAttribute('id', 'menu-list-box');
+    this.setAttribute('role', 'menu');
   }
 
   static get is() {

--- a/src/vaadin-message-menu-list-box.js
+++ b/src/vaadin-message-menu-list-box.js
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright (c) 2020 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ListBoxElement } from '@vaadin/vaadin-list-box/src/vaadin-list-box.js';
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+
+registerStyles(
+  'vaadin-message-menu-list-box',
+  css`
+    :host {
+    }
+  `,
+  { moduleId: 'vaadin-message-menu-list-box-styles' }
+);
+
+/**
+ * @extends PolymerElement
+ */
+class MessageMenuListBoxElement extends ListBoxElement {
+  ready() {
+    super.ready();
+  }
+
+  static get is() {
+    return 'vaadin-message-menu-list-box';
+  }
+}
+
+customElements.define(MessageMenuListBoxElement.is, MessageMenuListBoxElement);

--- a/src/vaadin-message-menu.js
+++ b/src/vaadin-message-menu.js
@@ -8,9 +8,9 @@ import { ContextMenuElement } from '@vaadin/vaadin-context-menu/src/vaadin-conte
 /**
  * @extends PolymerElement
  */
-class MessageContextMenuElement extends ContextMenuElement {
+class MessageMenuElement extends ContextMenuElement {
   static get is() {
-    return 'vaadin-message-context-menu';
+    return 'vaadin-message-menu';
   }
 
   constructor() {
@@ -38,4 +38,4 @@ class MessageContextMenuElement extends ContextMenuElement {
   }
 }
 
-customElements.define(MessageContextMenuElement.is, MessageContextMenuElement);
+customElements.define(MessageMenuElement.is, MessageMenuElement);

--- a/src/vaadin-message-menu.js
+++ b/src/vaadin-message-menu.js
@@ -15,6 +15,30 @@ class MessageMenuElement extends ContextMenuElement {
   static get is() {
     return 'vaadin-message-menu';
   }
+
+  constructor() {
+    super();
+    this.openOn = 'openmessagemenu';
+  }
+
+  ready() {
+    super.ready();
+    this.$.overlay.addEventListener('keydown', (event) => this._onKeyDown(event));
+  }
+
+  /** @private */
+  _onKeyDown(event) {
+    if (event.keyCode === 27) {
+      this.getRootNode().host._closeMenu(true);
+    }
+  }
+
+  /**
+   * Overriding the observer to not add global "contextmenu" listener.
+   */
+  _openedChanged(opened) {
+    this.$.overlay.opened = opened;
+  }
 }
 
 customElements.define(MessageMenuElement.is, MessageMenuElement);

--- a/src/vaadin-message-menu.js
+++ b/src/vaadin-message-menu.js
@@ -4,37 +4,16 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { ContextMenuElement } from '@vaadin/vaadin-context-menu/src/vaadin-context-menu.js';
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+
+registerStyles('vaadin-message-menu', css``, { moduleId: 'vaadin-message-menu-styles' });
 
 /**
- * @extends PolymerElement
+ * @extends HTMLElement
  */
 class MessageMenuElement extends ContextMenuElement {
   static get is() {
     return 'vaadin-message-menu';
-  }
-
-  constructor() {
-    super();
-    this.openOn = 'openmessagemenu';
-  }
-
-  /**
-   * Overriding the observer to not add global "contextmenu" listener.
-   */
-  _openedChanged(opened) {
-    this.$.overlay.opened = opened;
-  }
-
-  /**
-   * Overriding the public method to reset expanded button state.
-   */
-  close() {
-    super.close();
-
-    // only handle 1st level submenu
-    if (this.hasAttribute('is-root')) {
-      this.getRootNode().host._close();
-    }
   }
 }
 

--- a/src/vaadin-message-menu.js
+++ b/src/vaadin-message-menu.js
@@ -15,7 +15,7 @@ class MessageMenuElement extends ContextMenuElement {
 
   constructor() {
     super();
-    this.openOn = 'opensubmenu';
+    this.openOn = 'openmessagemenu';
   }
 
   /**

--- a/src/vaadin-message.js
+++ b/src/vaadin-message.js
@@ -237,7 +237,7 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
     const rect = button.getBoundingClientRect();
     requestAnimationFrame(() => {
       button.dispatchEvent(
-        new CustomEvent('opensubmenu', {
+        new CustomEvent('openmessagemenu', {
           detail: {
             x: this.__isRTL ? rect.right : rect.left,
             y: rect.bottom

--- a/src/vaadin-message.js
+++ b/src/vaadin-message.js
@@ -161,8 +161,10 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
             <span part="time">[[time]]</span>
           </div>
           <vaadin-context-menu open-on="click">
+            <!-- When the menu opens, we should set aria-expanded to 'true' -->
             <vaadin-button
               aria-controls="vaadin-message-actions-menu"
+              aria-expanded="false"
               aria-haspopup="true"
               aria-label="Actions"
               id="vaadin-message-actions-button"
@@ -199,13 +201,14 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
         listBox.setAttribute('role', 'menu');
       }
 
-      // This should probably not be hardcoded? :D
+      // This should probably not be hardcoded! :D
       const editMessage = window.document.createElement('vaadin-item');
       editMessage.textContent = 'Edit message';
       listBox.appendChild(editMessage);
 
       const deleteMessage = window.document.createElement('vaadin-item');
       deleteMessage.textContent = 'Delete message';
+      // This theme variant is coming soon!™
       deleteMessage.setAttribute('theme', 'error');
       listBox.appendChild(deleteMessage);
     };

--- a/src/vaadin-message.js
+++ b/src/vaadin-message.js
@@ -183,7 +183,7 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   ready() {
     super.ready();
 
-    const button = this.shadowRoot.querySelector('vaadin-message-menu-button');
+    const button = this._button;
     button.addEventListener('click', this._openMenu.bind(this));
     button.addEventListener('keydown', (e) => this._onKeydown(e));
   }
@@ -218,7 +218,7 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
       }
     }
 
-    const items = ['Edit', 'Delete'];
+    const items = [{ text: 'Edit message' }, { text: 'Delete message' }];
     menu.items = items;
     menu.listenOn = button;
 

--- a/src/vaadin-message.js
+++ b/src/vaadin-message.js
@@ -8,11 +8,11 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';
 import '@polymer/iron-icon/iron-icon.js';
 import '@vaadin/vaadin-avatar/src/vaadin-avatar.js';
-import '@vaadin/vaadin-button/src/vaadin-button.js';
-import '@vaadin/vaadin-context-menu/src/vaadin-context-menu.js';
 import '@vaadin/vaadin-icons/vaadin-icons.js';
-import './vaadin-message-context-menu.js';
+import './vaadin-message-menu.js';
 import './vaadin-message-menu-button.js';
+import './vaadin-message-menu-item.js';
+import './vaadin-message-menu-list-box.js';
 
 /**
  * `<vaadin-message>` is a Web Component for showing a single message with an author, message and time.
@@ -162,7 +162,7 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
             <span part="time">[[time]]</span>
           </div>
           <vaadin-message-menu-button
-            aria-controls="vaadin-message-context-menu"
+            aria-controls="vaadin-message-menu-list-box"
             aria-expanded="false"
             aria-haspopup="true"
             aria-label="Menu"
@@ -171,7 +171,18 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
           >
             <span class="dots"></span>
           </vaadin-message-menu-button>
-          <vaadin-message-context-menu></vaadin-message-context-menu>
+          <vaadin-message-menu>
+            <template>
+              <vaadin-message-menu-list-box
+                aria-labelledby="vaadin-message-menu-button"
+                id="vaadin-message-menu-list-box"
+                role="menu"
+              >
+                <vaadin-message-menu-item role="menuitem">Edit message</vaadin-message-menu-item>
+                <vaadin-message-menu-item role="menuitem" theme="error">Delete message</vaadin-message-menu-item>
+              </vaadin-message-menu-list-box>
+            </template>
+          </vaadin-message-menu>
         </div>
         <div part="message">
           <slot></slot>
@@ -201,7 +212,7 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
    * @protected
    */
   get _menu() {
-    return this.shadowRoot.querySelector('vaadin-message-context-menu');
+    return this.shadowRoot.querySelector('vaadin-message-menu');
   }
 
   /* private */
@@ -218,8 +229,6 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
       }
     }
 
-    const items = [{ text: 'Edit message' }, { text: 'Delete message' }];
-    menu.items = items;
     menu.listenOn = button;
 
     const rect = button.getBoundingClientRect();
@@ -228,8 +237,7 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
         new CustomEvent('opensubmenu', {
           detail: {
             x: this.__isRTL ? rect.right : rect.left,
-            y: rect.bottom,
-            children: items
+            y: rect.bottom
           }
         })
       );

--- a/src/vaadin-message.js
+++ b/src/vaadin-message.js
@@ -6,7 +6,12 @@
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';
+import '@polymer/iron-icon/iron-icon.js';
 import '@vaadin/vaadin-avatar/src/vaadin-avatar.js';
+import '@vaadin/vaadin-button/src/vaadin-button.js';
+import '@vaadin/vaadin-context-menu/src/vaadin-context-menu.js';
+import '@vaadin/vaadin-icons/vaadin-icons.js';
+
 /**
  * `<vaadin-message>` is a Web Component for showing a single message with an author, message and time.
  *
@@ -105,6 +110,7 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
         :host {
           display: flex;
           flex-direction: row;
+          position: relative;
         }
 
         :host([hidden]) {
@@ -124,10 +130,19 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
         }
 
         [part='header'] {
-          align-items: baseline;
           display: flex;
-          flex-direction: row;
+        }
+
+        [part='sender'] {
+          align-items: center;
+          display: flex;
+          flex-grow: 1;
           flex-wrap: wrap;
+        }
+
+        vaadin-button {
+          flex-shrink: 0;
+          line-height: 1;
         }
       </style>
       <vaadin-avatar
@@ -141,8 +156,21 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
       ></vaadin-avatar>
       <div part="content">
         <div part="header">
-          <span part="name">[[userName]]</span>
-          <span part="time">[[time]]</span>
+          <div part="sender">
+            <span part="name">[[userName]]</span>
+            <span part="time">[[time]]</span>
+          </div>
+          <vaadin-context-menu open-on="click">
+            <vaadin-button
+              aria-controls="vaadin-message-actions-menu"
+              aria-haspopup="true"
+              aria-label="Actions"
+              id="vaadin-message-actions-button"
+              theme="icon tertiary-inline"
+            >
+              <iron-icon aria-hidden="true" icon="vaadin:ellipsis-dots-v"></iron-icon>
+            </vaadin-button>
+          </vaadin-context-menu>
         </div>
         <div part="message">
           <slot></slot>
@@ -153,6 +181,34 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
 
   ready() {
     super.ready();
+
+    const contextMenu = this.shadowRoot.querySelector('vaadin-context-menu');
+    contextMenu.renderer = function (root) {
+      let listBox = root.firstElementChild;
+      if (listBox) {
+        listBox.innerHTML = '';
+      } else {
+        listBox = window.document.createElement('vaadin-list-box');
+        listBox.setAttribute('aria-labelledby', 'vaadin-message-actions-button');
+
+        // Unfortunately the vaadin-messages are in the shadow root, so this doesn't matter :/
+        listBox.setAttribute('id', 'vaadin-message-actions-menu');
+        root.appendChild(listBox);
+
+        // Must be set after appendChild, otherwise it gets overridden
+        listBox.setAttribute('role', 'menu');
+      }
+
+      // This should probably not be hardcoded? :D
+      const editMessage = window.document.createElement('vaadin-item');
+      editMessage.textContent = 'Edit message';
+      listBox.appendChild(editMessage);
+
+      const deleteMessage = window.document.createElement('vaadin-item');
+      deleteMessage.textContent = 'Delete message';
+      deleteMessage.setAttribute('theme', 'error');
+      listBox.appendChild(deleteMessage);
+    };
   }
 
   static get is() {

--- a/src/vaadin-message.js
+++ b/src/vaadin-message.js
@@ -100,13 +100,6 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
        */
       userColorIndex: {
         type: Number
-      },
-
-      /** @private */
-      _opened: {
-        type: Boolean,
-        observer: '__openedChanged',
-        value: false
       }
     };
   }
@@ -166,7 +159,7 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
             <span part="name">[[userName]]</span>
             <span part="time">[[time]]</span>
           </div>
-          <vaadin-message-menu open-on="click">
+          <vaadin-message-menu>
             <vaadin-message-menu-button
               aria-controls="menu-list-box"
               aria-expanded="false"
@@ -199,7 +192,7 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   ready() {
     super.ready();
 
-    const menu = this.shadowRoot.querySelector('vaadin-message-menu');
+    const menu = this._menu();
     menu.renderer = function (root) {
       let listBox = root.firstElementChild;
 
@@ -219,6 +212,35 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
       deleteItem.setAttribute('theme', 'error');
       listBox.appendChild(deleteItem);
     };
+  }
+
+  /** @private */
+  get _button() {
+    return this.shadowRoot.querySelector('vaadin-message-menu-button');
+  }
+
+  /** @private */
+  get _menu() {
+    return this.shadowRoot.querySelector('vaadin-message-menu');
+  }
+
+  /** @private */
+  _onMenuButtonClick(event) {
+    this._openMenu(event);
+  }
+
+  /** @private */
+  _onMenuButtonKeyDown(event) {
+    // Open menu on RETURN, SPACE or DOWN ARROW
+    if (event.keyCode === 13 || event.keyCode === 32 || event.keyCode === 40) {
+      this._openMenu(event);
+    }
+  }
+
+  /** @private */
+  _openMenu(event) {
+    this._button().setAttribute('aria-expanded', 'true');
+    this._menu().open(event);
   }
 }
 

--- a/src/vaadin-message.js
+++ b/src/vaadin-message.js
@@ -11,6 +11,8 @@ import '@vaadin/vaadin-avatar/src/vaadin-avatar.js';
 import '@vaadin/vaadin-button/src/vaadin-button.js';
 import '@vaadin/vaadin-context-menu/src/vaadin-context-menu.js';
 import '@vaadin/vaadin-icons/vaadin-icons.js';
+import './vaadin-message-context-menu.js';
+import './vaadin-message-menu-button.js';
 
 /**
  * `<vaadin-message>` is a Web Component for showing a single message with an author, message and time.
@@ -140,9 +142,8 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
           flex-wrap: wrap;
         }
 
-        vaadin-button {
-          flex-shrink: 0;
-          line-height: 1;
+        .dots::before {
+          content: '\\00B7\\00B7\\00B7';
         }
       </style>
       <vaadin-avatar
@@ -160,19 +161,17 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
             <span part="name">[[userName]]</span>
             <span part="time">[[time]]</span>
           </div>
-          <vaadin-context-menu open-on="click">
-            <!-- When the menu opens, we should set aria-expanded to 'true' -->
-            <vaadin-button
-              aria-controls="vaadin-message-actions-menu"
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              id="vaadin-message-actions-button"
-              theme="icon tertiary-inline"
-            >
-              <iron-icon aria-hidden="true" icon="vaadin:ellipsis-dots-v"></iron-icon>
-            </vaadin-button>
-          </vaadin-context-menu>
+          <vaadin-message-menu-button
+            aria-controls="vaadin-message-context-menu"
+            aria-expanded="false"
+            aria-haspopup="true"
+            aria-label="Menu"
+            id="vaadin-message-menu-button"
+            part="menu-button"
+          >
+            <span class="dots"></span>
+          </vaadin-message-menu-button>
+          <vaadin-message-context-menu></vaadin-message-context-menu>
         </div>
         <div part="message">
           <slot></slot>
@@ -184,17 +183,17 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   ready() {
     super.ready();
 
-    const contextMenu = this.shadowRoot.querySelector('vaadin-context-menu');
+    const contextMenu = this.shadowRoot.querySelector('vaadin-message-context-menu');
     contextMenu.renderer = function (root) {
       let listBox = root.firstElementChild;
       if (listBox) {
         listBox.innerHTML = '';
       } else {
         listBox = window.document.createElement('vaadin-list-box');
-        listBox.setAttribute('aria-labelledby', 'vaadin-message-actions-button');
+        listBox.setAttribute('aria-labelledby', 'vaadin-message-menu-button');
 
         // Unfortunately the vaadin-messages are in the shadow root, so this doesn't matter :/
-        listBox.setAttribute('id', 'vaadin-message-actions-menu');
+        listBox.setAttribute('id', 'vaadin-message-context-menu');
         root.appendChild(listBox);
 
         // Must be set after appendChild, otherwise it gets overridden
@@ -208,6 +207,7 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
 
       const deleteMessage = window.document.createElement('vaadin-item');
       deleteMessage.textContent = 'Delete message';
+
       // This theme variant is coming soon!™
       deleteMessage.setAttribute('theme', 'error');
       listBox.appendChild(deleteMessage);

--- a/src/vaadin-message.js
+++ b/src/vaadin-message.js
@@ -167,6 +167,8 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
             aria-haspopup="true"
             aria-label="Menu"
             id="vaadin-message-menu-button"
+            on-click="_onMenuButtonClick"
+            on-keydown="_onMenuButtonKeyDown"
             part="menu-button"
           >
             <span class="dots"></span>
@@ -193,10 +195,6 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
 
   ready() {
     super.ready();
-
-    const button = this._button;
-    button.addEventListener('click', this._openMenu.bind(this));
-    button.addEventListener('keydown', (e) => this._onKeydown(e));
   }
 
   /**
@@ -213,6 +211,11 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
    */
   get _menu() {
     return this.shadowRoot.querySelector('vaadin-message-menu');
+  }
+
+  /* private */
+  _onMenuButtonClick(event) {
+    this._openMenu(event);
   }
 
   /* private */
@@ -307,7 +310,7 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
    * @param {!KeyboardEvent} event
    * @protected
    */
-  _onKeydown(event) {
+  _onMenuButtonKeyDown(event) {
     if (event.keyCode === 40) {
       // ArrowDown, prevent page scroll
       event.preventDefault();

--- a/src/vaadin-message.js
+++ b/src/vaadin-message.js
@@ -234,14 +234,14 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
 
   /** @private */
   _onMenuButtonKeyDown(event) {
-    event.preventDefault();
-
     // RETURN, SPACE, DOWN ARROW: open menu & focus first item
     if (event.keyCode === 13 || event.keyCode === 32 || event.keyCode === 40) {
+      event.preventDefault();
       this._openMenu(event);
 
       // UP ARROW: open menu & focus last item
     } else if (event.keyCode === 38) {
+      event.preventDefault();
       this._openMenu(event, { focusLast: true });
     }
   }

--- a/theme/lumo/vaadin-message-menu-button-styles.js
+++ b/theme/lumo/vaadin-message-menu-button-styles.js
@@ -4,16 +4,21 @@ import '@vaadin/vaadin-lumo-styles/typography.js';
 import '@vaadin/vaadin-button/theme/lumo/vaadin-button.js';
 
 registerStyles(
-  'vaadin-message-menu-button-styles',
+  'vaadin-message-menu-button',
   css`
-    :host {
+    :host([part='menu-button']) {
       align-self: flex-start;
       background: none;
-      height: var(--lumo-icon-size-m);
-      margin: calc(((var(--lumo-font-size-m) * var(--lumo-line-height-m)) - var(--lumo-icon-size-m)) / 2) 0 0 0;
+      margin: calc(((var(--lumo-font-size-m) * var(--lumo-line-height-m)) - var(--lumo-button-size)) / 2);
       min-width: 0;
       padding: 0;
-      width: var(--lumo-icon-size-m);
+      width: var(--lumo-button-size);
+    }
+
+    :host([part='menu-button']) ::slotted(*) {
+      display: block;
+      font-size: var(--lumo-font-size-xl);
+      transform: rotate(90deg);
     }
   `,
   { include: ['lumo-button'], moduleId: 'lumo-message-menu-button' }

--- a/theme/lumo/vaadin-message-menu-button-styles.js
+++ b/theme/lumo/vaadin-message-menu-button-styles.js
@@ -1,0 +1,20 @@
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import '@vaadin/vaadin-lumo-styles/sizing.js';
+import '@vaadin/vaadin-lumo-styles/typography.js';
+import '@vaadin/vaadin-button/theme/lumo/vaadin-button.js';
+
+registerStyles(
+  'vaadin-message-menu-button-styles',
+  css`
+    :host {
+      align-self: flex-start;
+      background: none;
+      height: var(--lumo-icon-size-m);
+      margin: calc(((var(--lumo-font-size-m) * var(--lumo-line-height-m)) - var(--lumo-icon-size-m)) / 2) 0 0 0;
+      min-width: 0;
+      padding: 0;
+      width: var(--lumo-icon-size-m);
+    }
+  `,
+  { include: ['lumo-button'], moduleId: 'lumo-message-menu-button' }
+);

--- a/theme/lumo/vaadin-message-menu-item-styles.js
+++ b/theme/lumo/vaadin-message-menu-item-styles.js
@@ -1,0 +1,4 @@
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import '@vaadin/vaadin-item/theme/lumo/vaadin-item-styles.js';
+
+registerStyles('vaadin-message-menu-item', css``, { include: ['lumo-item'], moduleId: 'lumo-message-menu-item' });

--- a/theme/lumo/vaadin-message-menu-list-box-styles.js
+++ b/theme/lumo/vaadin-message-menu-list-box-styles.js
@@ -1,7 +1,47 @@
 import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import '@vaadin/vaadin-list-box/theme/lumo/vaadin-list-box-styles.js';
 
-registerStyles('vaadin-message-menu-list-box', css``, {
-  include: ['lumo-list-box'],
-  moduleId: 'lumo-message-menu-list-box'
-});
+registerStyles(
+  'vaadin-message-menu-list-box',
+  css`
+    /* Normal item */
+    [part='items'] ::slotted(vaadin-message-menu-item) {
+      -webkit-tap-highlight-color: var(--lumo-primary-color-10pct);
+      cursor: default;
+    }
+
+    [part='items'] ::slotted(vaadin-message-menu-item) {
+      outline: none;
+      border-radius: var(--lumo-border-radius);
+      padding-left: var(--_lumo-list-box-item-padding-left, calc(var(--lumo-border-radius) / 4));
+      padding-right: calc(var(--lumo-space-l) + var(--lumo-border-radius) / 4);
+    }
+
+    /* Workaround to display checkmark in IE11 when list-box is not used in dropdown-menu */
+    [part='items'] ::slotted(vaadin-message-menu-item)::before {
+      display: var(--_lumo-item-selected-icon-display);
+    }
+
+    /* Hovered item */
+    /* TODO a workaround until we have "focus-follows-mouse". After that, use the hover style for focus-ring as well */
+    [part='items'] ::slotted(vaadin-message-menu-item:hover:not([disabled])) {
+      background-color: var(--lumo-primary-color-10pct);
+    }
+
+    @media (pointer: coarse) {
+      [part='items'] ::slotted(vaadin-message-menu-item:hover:not([disabled])) {
+        background-color: transparent;
+      }
+    }
+
+    /* RTL specific styles */
+    :host([dir='rtl']) [part='items'] ::slotted(vaadin-message-menu-item) {
+      padding-left: calc(var(--lumo-space-l) + var(--lumo-border-radius) / 4);
+      padding-right: var(--_lumo-list-box-item-padding-left, calc(var(--lumo-border-radius) / 4));
+    }
+  `,
+  {
+    include: ['lumo-list-box'],
+    moduleId: 'lumo-message-menu-list-box'
+  }
+);

--- a/theme/lumo/vaadin-message-menu-list-box-styles.js
+++ b/theme/lumo/vaadin-message-menu-list-box-styles.js
@@ -1,0 +1,7 @@
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import '@vaadin/vaadin-list-box/theme/lumo/vaadin-list-box-styles.js';
+
+registerStyles('vaadin-message-menu-list-box', css``, {
+  include: ['lumo-list-box'],
+  moduleId: 'lumo-message-menu-list-box'
+});

--- a/theme/lumo/vaadin-message-menu-styles.js
+++ b/theme/lumo/vaadin-message-menu-styles.js
@@ -1,0 +1,4 @@
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import '@vaadin/vaadin-context-menu/theme/lumo/vaadin-context-menu-styles.js';
+
+registerStyles('vaadin-message-menu', css``, { moduleId: 'lumo-message-menu' });

--- a/theme/lumo/vaadin-message-styles.js
+++ b/theme/lumo/vaadin-message-styles.js
@@ -5,6 +5,8 @@ import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
 import '@vaadin/vaadin-avatar/theme/lumo/vaadin-avatar.js';
+import '@vaadin/vaadin-button/theme/lumo/vaadin-button.js';
+import '@vaadin/vaadin-context-menu/theme/lumo/vaadin-context-menu.js';
 
 registerStyles(
   'vaadin-message',
@@ -31,7 +33,7 @@ registerStyles(
     }
 
     [part='name'] {
-      font-weight: 500;
+      font-weight: 600;
       margin-right: var(--lumo-space-s);
     }
 
@@ -43,6 +45,11 @@ registerStyles(
     [part='time'] {
       color: var(--lumo-secondary-text-color);
       font-size: var(--lumo-font-size-s);
+    }
+
+    vaadin-button {
+      align-self: flex-start;
+      margin-top: calc(((var(--lumo-font-size-m) * var(--lumo-line-height-m)) - var(--lumo-icon-size-m)) / 2);
     }
   `,
   { moduleId: 'lumo-message' }

--- a/theme/lumo/vaadin-message-styles.js
+++ b/theme/lumo/vaadin-message-styles.js
@@ -5,8 +5,7 @@ import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
 import '@vaadin/vaadin-avatar/theme/lumo/vaadin-avatar.js';
-import '@vaadin/vaadin-button/theme/lumo/vaadin-button.js';
-import '@vaadin/vaadin-context-menu/theme/lumo/vaadin-context-menu.js';
+import './vaadin-message-menu-button-styles.js';
 
 registerStyles(
   'vaadin-message',
@@ -45,11 +44,6 @@ registerStyles(
     [part='time'] {
       color: var(--lumo-secondary-text-color);
       font-size: var(--lumo-font-size-s);
-    }
-
-    vaadin-button {
-      align-self: flex-start;
-      margin-top: calc(((var(--lumo-font-size-m) * var(--lumo-line-height-m)) - var(--lumo-icon-size-m)) / 2);
     }
   `,
   { moduleId: 'lumo-message' }

--- a/theme/lumo/vaadin-message-styles.js
+++ b/theme/lumo/vaadin-message-styles.js
@@ -5,8 +5,10 @@ import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
 import '@vaadin/vaadin-avatar/theme/lumo/vaadin-avatar-styles.js';
-import '@vaadin/vaadin-context-menu/theme/lumo/vaadin-context-menu-styles.js';
 import './vaadin-message-menu-button-styles.js';
+import './vaadin-message-menu-item-styles.js';
+import './vaadin-message-menu-list-box-styles.js';
+import './vaadin-message-menu-styles.js';
 
 registerStyles(
   'vaadin-message',

--- a/theme/lumo/vaadin-message-styles.js
+++ b/theme/lumo/vaadin-message-styles.js
@@ -4,7 +4,8 @@ import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import '@vaadin/vaadin-avatar/theme/lumo/vaadin-avatar.js';
+import '@vaadin/vaadin-avatar/theme/lumo/vaadin-avatar-styles.js';
+import '@vaadin/vaadin-context-menu/theme/lumo/vaadin-context-menu-styles.js';
 import './vaadin-message-menu-button-styles.js';
 
 registerStyles(
@@ -28,6 +29,15 @@ registerStyles(
 
     :host([dir='rtl']) vaadin-avatar {
       margin-left: var(--lumo-space-m);
+      margin-right: 0;
+    }
+
+    [part='sender'] {
+      margin-right: var(--lumo-space-s);
+    }
+
+    :host([dir='rtl']) [part='sender'] {
+      margin-left: var(--lumo-space-s);
       margin-right: 0;
     }
 

--- a/theme/material/vaadin-message-menu-button-styles.js
+++ b/theme/material/vaadin-message-menu-button-styles.js
@@ -2,7 +2,7 @@ import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styl
 import '@vaadin/vaadin-button/theme/material/vaadin-button-styles.js';
 
 registerStyles(
-  'vaadin-message-menu-button-styles',
+  'vaadin-message-menu-button',
   css`
     :host {
       border-radius: 50%;

--- a/theme/material/vaadin-message-menu-button-styles.js
+++ b/theme/material/vaadin-message-menu-button-styles.js
@@ -1,0 +1,21 @@
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import '@vaadin/vaadin-button/theme/material/vaadin-button-styles.js';
+
+registerStyles(
+  'vaadin-message-menu-button-styles',
+  css`
+    :host {
+      border-radius: 50%;
+      height: 2.5rem;
+      margin: -0.5rem -0.5rem -0.5rem 0.5rem;
+      min-width: 0;
+      padding: 0;
+      width: 2.5rem;
+    }
+
+    :host([dir='rtl']) {
+      margin: -0.5rem 0.5rem -0.5rem -0.5rem;
+    }
+  `,
+  { include: ['material-button'], moduleId: 'material-message-menu-button' }
+);

--- a/theme/material/vaadin-message-menu-button-styles.js
+++ b/theme/material/vaadin-message-menu-button-styles.js
@@ -16,6 +16,12 @@ registerStyles(
     :host([dir='rtl']) {
       margin: -0.5rem 0.5rem -0.5rem -0.5rem;
     }
+
+    :host([part='menu-button']) ::slotted(*) {
+      display: block;
+      font-size: var(--material-icon-font-size);
+      transform: rotate(90deg);
+    }
   `,
   { include: ['material-button'], moduleId: 'material-message-menu-button' }
 );

--- a/theme/material/vaadin-message-menu-item-styles.js
+++ b/theme/material/vaadin-message-menu-item-styles.js
@@ -1,0 +1,12 @@
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import '@vaadin/vaadin-item/theme/material/vaadin-item-styles.js';
+
+registerStyles(
+  'vaadin-message-menu-item',
+  css`
+    :host::before {
+      content: none;
+    }
+  `,
+  { include: ['material-item'], moduleId: 'material-message-menu-item' }
+);

--- a/theme/material/vaadin-message-menu-list-box-styles.js
+++ b/theme/material/vaadin-message-menu-list-box-styles.js
@@ -1,0 +1,32 @@
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import '@vaadin/vaadin-list-box/theme/material/vaadin-list-box-styles.js';
+
+registerStyles(
+  'vaadin-message-menu-list-box',
+  css`
+    [part='items'] ::slotted(vaadin-message-menu-item) {
+      font-size: var(--material-small-font-size);
+      height: 3rem;
+      padding: 0 1rem;
+    }
+
+    [part='items'] ::slotted(vaadin-message-menu-item:hover:not([disabled])) {
+      background-color: var(--material-secondary-background-color);
+    }
+
+    [part='items'] ::slotted(vaadin-message-menu-item[focused]:not([disabled])) {
+      background-color: var(--material-divider-color);
+    }
+
+    @media (pointer: coarse) {
+      [part='items'] ::slotted(vaadin-message-menu-item:hover:not([disabled])),
+      [part='items'] ::slotted(vaadin-message-menu-item[focused]:not([disabled])) {
+        background-color: transparent;
+      }
+    }
+  `,
+  {
+    include: ['material-list-box'],
+    moduleId: 'material-message-menu-list-box'
+  }
+);

--- a/theme/material/vaadin-message-menu-styles.js
+++ b/theme/material/vaadin-message-menu-styles.js
@@ -1,0 +1,4 @@
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import '@vaadin/vaadin-context-menu/theme/material/vaadin-context-menu-styles.js';
+
+registerStyles('vaadin-message-menu', css``, { moduleId: 'material-message-menu' });

--- a/theme/material/vaadin-message-styles.js
+++ b/theme/material/vaadin-message-styles.js
@@ -2,8 +2,7 @@ import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styl
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/typography.js';
 import '@vaadin/vaadin-avatar/theme/material/vaadin-avatar-styles.js';
-import '@vaadin/vaadin-button/theme/material/vaadin-button.js';
-import '@vaadin/vaadin-context-menu/material/lumo/vaadin-context-menu.js';
+import './vaadin-message-menu-button-styles.js';
 
 registerStyles(
   'vaadin-message',
@@ -52,24 +51,6 @@ registerStyles(
       color: var(--material-secondary-text-color);
       font-size: var(--material-small-font-size);
       line-height: 1.25rem;
-    }
-
-    vaadin-button {
-      border-radius: 50%;
-      height: 2.5rem;
-      margin: -0.5rem -0.5rem -0.5rem 0.5rem;
-      min-width: 0;
-      padding: 0;
-      width: 2.5rem;
-    }
-
-    :host([dir='rtl']) vaadin-button {
-      margin: -0.5rem 0.5rem -0.5rem -0.5rem;
-    }
-
-    vaadin-button iron-icon {
-      height: 1rem;
-      width: 1rem;
     }
   `,
   { moduleId: 'material-message' }

--- a/theme/material/vaadin-message-styles.js
+++ b/theme/material/vaadin-message-styles.js
@@ -2,6 +2,8 @@ import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styl
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/typography.js';
 import '@vaadin/vaadin-avatar/theme/material/vaadin-avatar-styles.js';
+import '@vaadin/vaadin-button/theme/material/vaadin-button.js';
+import '@vaadin/vaadin-context-menu/material/lumo/vaadin-context-menu.js';
 
 registerStyles(
   'vaadin-message',
@@ -28,12 +30,16 @@ registerStyles(
       margin-right: 0;
     }
 
+    [part='sender'] {
+      justify-content: space-between;
+    }
+
     [part='name'] {
-      margin-right: auto;
+      margin-right: 1rem;
     }
 
     :host([dir='rtl']) [part='name'] {
-      margin-left: auto;
+      margin-left: 1rem;
       margin-right: 0;
     }
 
@@ -46,6 +52,24 @@ registerStyles(
       color: var(--material-secondary-text-color);
       font-size: var(--material-small-font-size);
       line-height: 1.25rem;
+    }
+
+    vaadin-button {
+      border-radius: 50%;
+      height: 2.5rem;
+      margin: -0.5rem -0.5rem -0.5rem 0.5rem;
+      min-width: 0;
+      padding: 0;
+      width: 2.5rem;
+    }
+
+    :host([dir='rtl']) vaadin-button {
+      margin: -0.5rem 0.5rem -0.5rem -0.5rem;
+    }
+
+    vaadin-button iron-icon {
+      height: 1rem;
+      width: 1rem;
     }
   `,
   { moduleId: 'material-message' }

--- a/theme/material/vaadin-message-styles.js
+++ b/theme/material/vaadin-message-styles.js
@@ -2,6 +2,7 @@ import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styl
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/typography.js';
 import '@vaadin/vaadin-avatar/theme/material/vaadin-avatar-styles.js';
+import '@vaadin/vaadin-context-menu/material/lumo/vaadin-context-menu-styles.js';
 import './vaadin-message-menu-button-styles.js';
 
 registerStyles(

--- a/theme/material/vaadin-message-styles.js
+++ b/theme/material/vaadin-message-styles.js
@@ -2,8 +2,10 @@ import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styl
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/typography.js';
 import '@vaadin/vaadin-avatar/theme/material/vaadin-avatar-styles.js';
-import '@vaadin/vaadin-context-menu/material/lumo/vaadin-context-menu-styles.js';
 import './vaadin-message-menu-button-styles.js';
+import './vaadin-message-menu-item-styles.js';
+import './vaadin-message-menu-list-box-styles.js';
+import './vaadin-message-menu-styles.js';
 
 registerStyles(
   'vaadin-message',


### PR DESCRIPTION
If we can, and want to, render `<vaadin-message>` in `<vaadin-message-list>` in Light DOM, this menu should be somewhat accessible.

Followed this example:
https://www.w3.org/TR/2016/WD-wai-aria-practices-1.1-20161214/examples/menu-button/menu-button-1/menu-button-1.html

This is just a prototype, it'll need some proper development to be production ready. For example, the menu items don't do anything just yet and they are hard-coded.