### PR TITLE
feat: add disabled property to vaadin-message-input

### DIFF
--- a/src/vaadin-message-input.js
+++ b/src/vaadin-message-input.js
@@ -61,6 +61,16 @@ class MessageInputElement extends ElementMixin(ThemableMixin(PolymerElement)) {
           message: 'Message'
         }),
         observer: '__i18nChanged'
+      },
+
+      /**
+       * Set to true to disable this element.
+       * @type {boolean}
+       */
+      disabled: {
+        type: Boolean,
+        value: false,
+        reflectToAttribute: true
       }
     };
   }
@@ -85,8 +95,8 @@ class MessageInputElement extends ElementMixin(ThemableMixin(PolymerElement)) {
           margin: 0;
         }
       </style>
-      <vaadin-text-area value="{{value}}" placeholder="[[i18n.message]]"></vaadin-text-area>
-      <vaadin-button theme="primary contained" on-click="__submit">[[i18n.send]]</vaadin-button>
+      <vaadin-text-area disabled="[[disabled]]" value="{{value}}" placeholder="[[i18n.message]]"></vaadin-text-area>
+      <vaadin-button disabled="[[disabled]]" theme="primary contained" on-click="__submit">[[i18n.send]]</vaadin-button>
     `;
   }
 

--- a/test/message-input.test.js
+++ b/test/message-input.test.js
@@ -107,15 +107,24 @@ describe('message-input', () => {
     });
   });
 
-  describe('disabled attribute propagation', () => {
+  describe('disabled property', () => {
+    it('should be false by default', () => {
+      expect(messageInput.disabled).to.be.false;
+    });
+
+    it('should be reflected to the attribute', () => {
+      messageInput.disabled = true;
+      expect(messageInput.getAttribute('disabled')).to.exist;
+    });
+
     it('should be propagated to text-area', () => {
       messageInput.disabled = true;
-      expect(textArea.getAttribute('disabled')).to.exist;
+      expect(textArea.disabled).to.be.true;
     });
 
     it('should be propagated to button', () => {
       messageInput.disabled = true;
-      expect(button.getAttribute('disabled')).to.exist;
+      expect(button.disabled).to.be.true;
     });
   });
 });

--- a/test/message-input.test.js
+++ b/test/message-input.test.js
@@ -106,4 +106,16 @@ describe('message-input', () => {
       expect(textArea.inputElement.getAttribute('aria-label')).to.be.equal('Viesti');
     });
   });
+
+  describe('disabled attribute propagation', () => {
+    it('should be propagated to text-area', () => {
+      messageInput.disabled = true;
+      expect(textArea.getAttribute('disabled')).to.exist;
+    });
+
+    it('should be propagated to button', () => {
+      messageInput.disabled = true;
+      expect(button.getAttribute('disabled')).to.exist;
+    });
+  });
 });


### PR DESCRIPTION
Add disabled attribute to `vaadin-message-input`.

Closes https://github.com/vaadin/vaadin-messages/issues/36.