### PR TITLE
fix: set flex-shrink:0 for vaadin-message-input

### DIFF
--- a/src/vaadin-message-input.js
+++ b/src/vaadin-message-input.js
@@ -84,6 +84,7 @@ class MessageInputElement extends ElementMixin(ThemableMixin(PolymerElement)) {
           display: flex;
           max-height: 50vh;
           overflow: hidden;
+          flex-shrink: 0;
         }
         vaadin-text-area {
           align-self: stretch;


### PR DESCRIPTION
This improves the behavior in a typical setup, when used in a `vaadin-vertical-layout` with an expanded `vaadin-message-list`.